### PR TITLE
Record files properly to fasd

### DIFF
--- a/conf.d/__fasd_run.fish
+++ b/conf.d/__fasd_run.fish
@@ -1,4 +1,4 @@
   function __fasd_run -e fish_preexec -d "fasd takes record of the directories changed into"
-    command fasd --proc (command fasd --sanitize "$argv") > "/dev/null" 2>&1 &
+    command fasd --proc (command fasd --sanitize "$argv" | tr -s ' ' \n) > "/dev/null" 2>&1 &
   end
   


### PR DESCRIPTION
Incorperate the change introduced in oh-my-fish/plugin-fasd/pull/10 to solve argument separation in the fasd `fish_preexec` method.

> tl;dr: makes it so fasd can do files as well as folders

Fixes #7 