### PR TITLE
Explicit fasd in cd function instead of implicit on postexec

### DIFF
--- a/conf.d/__fasd_run.fish
+++ b/conf.d/__fasd_run.fish
@@ -1,6 +1,0 @@
-function __fasd_run -e fish_postexec -d "fasd takes record of the directories changed into"
-  set -lx RETVAL $status
-  if test $RETVAL -eq 0 # if there was no error
-    command fasd --proc (command fasd --sanitize (eval echo "$argv") | tr -s " " \n) > "/dev/null" 2>&1 &
-  end
-end

--- a/conf.d/aliases.fish
+++ b/conf.d/aliases.fish
@@ -1,3 +1,0 @@
-# support oldschool autojump user
-alias j  z
-alias jj zz

--- a/functions/cd.fish
+++ b/functions/cd.fish
@@ -1,4 +1,4 @@
-function cd -d "Change directory and register"
+function cd -d "Register directory and change to directory"
   fasd -A $argv
   builtin cd $argv
 end

--- a/functions/cd.fish
+++ b/functions/cd.fish
@@ -1,0 +1,5 @@
+function cd -d "Change directory and register"
+  fasd -A $argv
+  builtin cd $argv
+end
+


### PR DESCRIPTION
A cautious PR to address https://github.com/fishgretel/fasd/issues/16.

Cautious because it works for what I need, however it is opinionated in the override of cd. It will also regress behaviour for anyone who was relying on the implicit effect of fish postexec. This change causes the fasd register to only occur when you use cd. I'm raising this PR since it may help find the right direction - happy for any iteration / debate / alternatives.