### PR TITLE
Fix __fasd_run.fish eval bug

### DIFF
--- a/conf.d/__fasd_run.fish
+++ b/conf.d/__fasd_run.fish
@@ -1,6 +1,19 @@
-function __fasd_run -e fish_postexec -d "fasd takes record of the directories changed into"
+function __fasd_expand_vars -d "Expands only the first occurance of a variable in the passed string without evaluating the string"
+  set -lx vars (echo -n $argv | grep -oP '(?!\\\\)\$\K([A-z_][A-z0-9_]*?)([^A-z0-9_]|\b|\n)' | perl -pe 's/(.+?)(?:[^A-z0-9_]|\b)$/\1\n/' | sort -u)
+  for var in $vars
+    # Only replace if the variable is defined
+    if set -q $var
+      # Replacing the variable once is enough
+      set argv (string replace -r '([^\\\\]|\b)\$'"$var" '$1'"$$var" "$argv") 
+    end
+  end
+  # The following pipe does the same thing as fasd --sanitize
+  printf '%s\\n' "$argv" | sed -e 's/\([^\]\)$( *[^ ]* *\([^)]*\)))*/\1\2/g' -e 's/\([^\]\)[|&;<>$`{}]\{1,\}/\1 /g' | tr -s " " \n
+end
+
+function __fasd_run -e fish_postexec -d "fasd records the directories changed into"
   set -lx RETVAL $status
   if test $RETVAL -eq 0 # if there was no error
-    command fasd --proc (command fasd --sanitize (eval echo "$argv") | tr -s " " \n) > "/dev/null" 2>&1 &
+    command fasd --proc (__fasd_expand_vars $argv) > "/dev/null" 2>&1 &
   end
 end


### PR DESCRIPTION
This PR fixes issues #16, #17, and #18.

The fix adds a function that expands variables without evaluating the passed string in the `__fasd_run` function.

This allows constructs such as redirections, loops, glob expansions, etc... to not be affected by the fish_postexec hook.
This lets fasd take account of relative directories.

The following is an example of save variable expansion when a for loop is passed:
```fish
$ set folders foo bar baz
$ __fasd_expand_vars 'for f in $folders; echo \$folders; cd $f; cd $abc; echo $folders; end'
for
f
in
foo
bar
baz
echo
\$folders
cd
f
cd
abc
echo
folders
end
```
Variables are also expanded correctly if the input is multi-line:
```fish
$ set folders foo bar baz
$ __fasd_expand_vars 'for f in $folders
  echo \$folders
  cd $f
  cd $abc
  echo $folders
end'
for
f
in
foo
bar
baz
echo
\$folders
cd
f
cd
abc
echo
folders
end
```